### PR TITLE
Correct some words

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ go install github.com/yuk1ty/readygo@latest
 
 `readygo` has the following options:
 
-- `--name` or `-n`: Name for the directory which is created by `readygo`. This option can be omitted.
-- `--pkg-name` or `-p`: Package name for `go mod init` command.
+- `--dir-name` or `-n`: Name for the directory which is created by `readygo`. This option can be omitted.
+- `--module-path` or `-p`: Module path for `go mod init` command.
 - `--layout` or `-l`: Directory layout style. You can choose [Standard Go Project Layout](https://github.com/golang-standards/project-layout) style (`standard`) or empty style (`default`). This option can be omitted. The default value is `default`, creates an empty directory.
 
 ### Examples
@@ -43,16 +43,16 @@ Usage:
   readygo [flags]
 
 Flags:
-  -h, --help              help for readygo
-  -l, --layout default    Define your project layout. You can choose default or `standard`. If you omit this option, the value becomes `default`. (default "default")
-  -n, --name string       Define the directory name of your project. This can be omitted. If you do so, name will be extracted from package name.
-  -p, --pkg-name string   Define your package name. This is used for go mod init [module path].
+  -n, --dir-name string      Define the directory name of your project. This can be omitted. If you do so, the name will be extracted from its package name.
+  -h, --help                 help for readygo
+  -l, --layout default       Define your project layout. You can choose default or `standard`. If you omit this option, the value becomes `default`. (default "default")
+  -p, --module-path string   Define your module path. This is used for go mod init [module path].
 ```
 
 #### Full
 
 ```shell
-readygo --name newprj --pkg-name github.com/yuk1ty/example
+readygo --dir-name newprj --module-path github.com/yuk1ty/example
 ```
 
 generates
@@ -94,7 +94,7 @@ example
 └── pkg
 ```
 
-#### Omit `--name(-n)`
+#### Omit `--dir-name(-n)`
 
 ```shell
 readygo -p github.com/yuk1ty/example

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,7 +15,7 @@ var rootCmd = &cobra.Command{
 	Short: "The easiest way to get started with Go.",
 	Long:  `readygo is a tiny CLI tool for creating basic Go project.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		pkgName, err := parsePackageName(cmd)
+		pkgName, err := parsePackagePath(cmd)
 		if err != nil {
 			fmt.Println(err)
 			return
@@ -41,26 +41,26 @@ var rootCmd = &cobra.Command{
 	},
 }
 
-func parsePackageName(cmd *cobra.Command) (*string, error) {
-	pkgName, err := cmd.Flags().GetString("pkg-name")
+func parsePackagePath(cmd *cobra.Command) (*string, error) {
+	pkgName, err := cmd.Flags().GetString("module-path")
 	if err != nil {
 		fmt.Println(err)
 		return nil, err
 	}
 	if pkgName == "" {
-		return nil, errors.New("[ERROR] Package name should be set! Please use `--pkg-name` option. For more details, please hit --help option")
+		return nil, errors.New("[ERROR] Module path should be set! Please use `--module-path` option. For more details, please hit --help option")
 	}
 	return &pkgName, nil
 }
 
-func parseDirectoryName(cmd *cobra.Command, pkgName *string) (*string, error) {
-	name, err := cmd.Flags().GetString("name")
+func parseDirectoryName(cmd *cobra.Command, pkgPath *string) (*string, error) {
+	name, err := cmd.Flags().GetString("dir-name")
 	if err != nil {
 		return nil, err
 	}
 	if name == "" {
 		// e.g. If passed `github.com/yuk1ty/readygo` then extract `readygo`
-		splitted := strings.Split(*pkgName, "/")
+		splitted := strings.Split(*pkgPath, "/")
 		name = splitted[len(splitted)-1]
 	}
 	return &name, nil
@@ -197,7 +197,7 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.Flags().StringP("pkg-name", "p", "", "Define your package name. This is used for go mod init [module path].")
-	rootCmd.Flags().StringP("name", "n", "", "Define the directory name of your project. This can be omitted. If you do so, the name will be extracted from its package name.")
+	rootCmd.Flags().StringP("module-path", "p", "", "Define your module path. This is used for go mod init [module path].")
+	rootCmd.Flags().StringP("dir-name", "n", "", "Define the directory name of your project. This can be omitted. If you do so, the name will be extracted from its package name.")
 	rootCmd.Flags().StringP("layout", "l", "default", "Define your project layout. You can choose `default` or `standard`. If you omit this option, the value becomes `default`.")
 }


### PR DESCRIPTION
- `--pkg-name` to "module path" to align with Go's `go mod` wording.
- `--name` to `--dir-name` to precise the meaning of option.
- including fixing README